### PR TITLE
Change BigInt to support Safari and iOS

### DIFF
--- a/packages/libra-web-account/KeyFactory.ts
+++ b/packages/libra-web-account/KeyFactory.ts
@@ -51,7 +51,7 @@ export class KeyFactory {
   public generateKey(childDepth: number): KeyPair {
     // const childDepthBuffer = toBufferLE(BigInt(childDepth), 8)
     const childDepthBuffer = Buffer.from(
-      BigInt(childDepth)
+      Number(childDepth)
         .toString(16)
         .padStart(16, '0')
         .slice(0, 16),


### PR DESCRIPTION
"BigInt" is not supported on Safari and iOS, therefore generateKey will fail.
https://caniuse.com/#search=bigint

It is reproducible using the React example as well. Changing to Number solved the issue for me and works on iOS and Safari.